### PR TITLE
tweaks taxmap to match current open data download

### DIFF
--- a/Metadata/Metadata_AirRightsCondos.md
+++ b/Metadata/Metadata_AirRightsCondos.md
@@ -31,10 +31,11 @@ Geometry Type: SDE Table<br><br>
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| OID | Internal feature number. | OID | 
+| OBJECTID | Internal feature number. | OID | 
 | CONDO_KEY | This field is a concatenation of the Condo_boro and Condo_Number fields. | Long Int | 
-| CONDO_BASE | This field is the BBL for the base ot on which the condo is built. BBL is a concatenation of Boro-Block-Lot. | String | 
-| CONDO_BA_1 |  | String | 
+| CONDO_BASE | This field is the BBL for the base lot on which the condo is built. BBL is a concatenation of Boro-Block-Lot. | String | 
+| CONDO_BA00 |  | String | 
 | AIR_RIGHTS | This field is the BBL for the air lot on which the condo is built. BBL is a concatenation of Boro-Block-Lot | String | 
 | AV_CHANGE |  |  | 
 | BW_CHANGE |  |  | 
+| GLOBALID |  | String | 

--- a/Metadata/Metadata_AirRightsHolders.md
+++ b/Metadata/Metadata_AirRightsHolders.md
@@ -31,13 +31,14 @@ Geometry Type: SDE Table<br><br>
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| OID | Internal feature number. | OID | 
+| OBJECTID | Internal feature number. | OID | 
 | AIR_RIGHTS | Air Rights BBL is a concatenation of Boro-Block-Lot for the given feature. | String | 
 | HOLDING_BB | Holding BBL is a concatenation of Boro-Block-Lot for the given feature. This field relates to a BBL in the Tax_Lot_Polygon feature. | String | 
-| AIR_RIGH_1 |  | Long Int | 
+| AIR_RIGH00 |  | Long Int | 
 | CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
 | CREATED_DA | The date the feature was created | Date | 
 | LAST_MODIF | This field can be used to identify the operator who last modified the specific feature. | String | 
-| LAST_MOD_1 | The date the feature or any attribute value associated with it was changed. | Date | 
+| LAST_MOD00 | The date the feature or any attribute value associated with it was changed. | Date | 
 | AV_CHANGE |  |  | 
 | BW_CHANGE |  |  | 
+| GLOBALID |  | String | 

--- a/Metadata/Metadata_AirRightsLots.md
+++ b/Metadata/Metadata_AirRightsLots.md
@@ -31,19 +31,20 @@ Geometry Type: SDE Table<br><br>
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| OID | Internal feature number. | OID | 
-| DONATING_B | This is a one digiti number field that identifies the borough in which the associated feature (donor lot) exists. Boro values range from one (1) to five (5) and are validated against the D_BORO domain. | String | 
-| DONATING_1 | Donating block is a five digit numberic field that identifies the blokc on which the associated feature (donor lot) exists. | Long Integer | 
+| OBJECTID | Internal feature number. | OID | 
+| DONATING_B | This is a one digit number field that identifies the borough in which the associated feature (donor lot) exists. Boro values range from one (1) to five (5) and are validated against the D_BORO domain. | String | 
+| DONATING00 | Donating block is a five digit numberic field that identifies the blokc on which the associated feature (donor lot) exists. | Long Integer | 
 | DONATING_L | Four digit numeric filed that identifies a unique donating lot within a tax block. | Short Int | 
-| DONATING_2 | Donating BBL is a concatenation of Boro-Block-Lot and is stored with every instance of those threee fields. Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing, searching, and the use of the files by other, as yet undetermined applications.  | String | 
+| DONATING01 | Donating BBL is a concatenation of Boro-Block-Lot and is stored with every instance of those threee fields. Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing, searching, and the use of the files by other, as yet undetermined applications.  | String | 
 | AIR_RIGHTS | Air Rights BBL is a concatenation of Boro-Block-Lot for the Air lot. Air rights lot numbers must be between 9000 and 9989. | String | 
-| AIR_RIGH_1 |  | Long Int | 
+| AIR_RIGH00 |  | Long Int | 
 | USED_BY_DO |  | Short Integer | 
 | CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
 | CREATED_DA | The date the record was created | Date | 
 | LAST_MODIF | A field that can be used to identify the operator who last modified the specific feature. | String | 
-| LAST_MOD_1 | The date the feature or any attribute associated with it was changed. | Date | 
+| LAST_MOD00 | The date the feature or any attribute associated with it was changed. | Date | 
 | AV_CHANGE |  | Short Integer | 
 | BW_CHANGE |  | Short Integer | 
 | EFFECTIVE_ |  | String | 
-| AIR_RIGH_2 |  |  | 
+| AIR_RIGH01 |  |  | 
+| GLOBALID |  | String | 

--- a/Metadata/Metadata_Boundary.md
+++ b/Metadata/Metadata_Boundary.md
@@ -31,17 +31,18 @@ Geometry Type: SDE Feature Class<br><br>![image](https://github.com/CityOfNewYor
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
+| OBJECTID | Internal feature number. | OID | 
+| BOUNDARY_T | Integer value that indicates the subtype of boundary line. Default = 6. Legend: <br>3 - Pierhead and Bulkhead<br>8 - High Water Line<br>4 - REUC<br>5 - Riparian<br>6 - Unclassified<br>7 - Street Widening<br>2 - Pierhead<br>9 - Low Water Line<br>0 - Bulkhead<br>1 - Easement<br>11 - Pier<br>12 - Slope Line<br>13 - Deeded Rights | Short Integer | 
 | TYPE | This field is used to store the domain values associated with the sub-types.  Currently only the subtype of "Easement" has a domain associated with it. | Short Integer | 
 | ID_NUMBER | Various ID numbers, including REUC Idents. | String | 
+| DESCRIPTIO | Verbal description of BOUNDARY_TYPE field. | String |
 | LENGTH | Feature length | Double | 
 | MODIFIER | Domain: D_BOOLEAN_SYMBOL_VALUE | Short Integer | 
 | CREATED_BY | A field that can be used to identify the operator that created the feature. | String | 
-| SHAPE | Feature geometry. | Geometry | 
-| FID | Internal feature number. | FID | 
-| BOUNDARY_T | Integer value that indicates the subtype of boundary line. Default = 6. Legend: <br>3 - Pierhead and Bulkhead<br>8 - High Water Line<br>4 - REUC<br>5 - Riparian<br>6 - Unclassified<br>7 - Street Widening<br>2 - Pierhead<br>9 - Low Water Line<br>0 - Bulkhead<br>1 - Easement<br>11 - Pier<br>12 - Slope Line<br>13 - Deeded Rights | Short Integer | 
-| DESCRIPTIO | Verbal description of BOUNDARY_TYPE field. | String | 
 | CREATED_DA | The date the feature was created. | Date | 
 | LAST_MODIF | This field can be used to indicate the operator who last modified the feature | String | 
-| LAST_MOD_1 | The date the feature was last modified | Date | 
+| LAST_MOD00 | The date the feature was last modified | Date | 
 | EFFECTIVE_ | Effective Tax Year | String | 
+| GLOBALID |  | String | 
+| SHAPE | Feature geometry. | Geometry | 
 | SHAPE_Leng | Esri Automated shape length field | Double | 

--- a/Metadata/Metadata_Condo.md
+++ b/Metadata/Metadata_Condo.md
@@ -31,19 +31,20 @@ Geometry Type: SDE Table<br><br>
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| OID | Internal feature number. | OID | 
+| OBJECTID | Internal feature number. | OID | 
 | CONDO_BORO | Borough in which the condominium resides. | String | 
 | CONDO_KEY | This field is a concatenation of the Condo_Boro and Condo_number fields. | Long Integer | 
 | CONDO_NAME | This field represents the name of the condominium. | String | 
 | CONDO_BASE | This field is the BBL for the base lot on which the condo is built. BBL is a concatenation of Borough Block and Lot numbers.  | String | 
 | CONDO_BILL | This field is the concatenation of the billing lot's (series 7501, 7502, 7503, etc.) borough, block, and lot. Each record can only have a single Billing lot | String | 
-| CONDO_BA_1 |  |  | 
+| CONDO_BA_00 |  |  | 
 | AIR_RIGHTS | This flag is used to identify condominiums which are built on air rights lots. | Short Integer | 
 | BILLING_LO | The flag field is populated during the conversion process to indicate that the billing lot number for this condominium was not found in the COGIS file. | Short Integer | 
-| CREATED_BY | a fiedl that can be used to identify the operatior who created that specific feature | String | 
+| CREATED_BY | A field that can be used to identify the operatior who created that specific feature | String | 
 | CREATED_DA | The date the record was created | Date | 
 | LAST_MODIF | A field that can be used to identify the operator that last modified the field` | String | 
-| LAST_MOD_1 | The date the record was last modified | Date | 
+| LAST_MOD00 | The date the record was last modified | Date | 
 | AV_CHANGE |  |  | 
 | BW_CHANGE |  |  | 
+| GLOBALID |  | String | 
 | CONDO_NUMB | Five digit unique identifier for each condominium | Short Integer | 

--- a/Metadata/Metadata_CondoUnits.md
+++ b/Metadata/Metadata_CondoUnits.md
@@ -31,24 +31,25 @@ Geometry Type: SDE Table<br><br>
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| OID | Internal feature number. | Object ID | 
-| CONDO_BORO | This is a one digit numberic field that identifies the borough in which the associated feature exists. Boro values range from one (1) to five (5) and are vbalidated against the D_BORO domain.  | String | 
+| OBJECTID | Internal feature number. | Object ID | 
+| CONDO_BORO | This is a one digit numeric field that identifies the borough in which the associated feature exists. Boro values range from one (1) to five (5) and are validated against the D_BORO domain.  | String | 
 | CONDO_NUMB | A unique identifier for each condominium assigned at the time the condominium is created. Separated by Boro.  | Short Integer | 
 | CONDO_KEY | A concatenation of the Condo Boro and Condo Number Fields  | Long Integer | 
-| CONDO_BASE | The cocatenation of the borough block and lot of the parent lot for the condominium. | String | 
-| CONDO_BA_1 | A cocatenation of the Borough Block and Billing lot that the condo is built on. In the case of a condo on multiple parent lots, one billing lot can represent multiple base lots.  | String | 
-| CONDO_BA_2 | A concatenation of the Condo_Boro, Condo_Number and the Condo_Base_BBL fields. | String | 
-| CONDO_BA_3 |  |  | 
-| CONDO_BA_4 |  |  | 
+| CONDO_BASE | The concatenation of the borough block and lot of the parent lot for the condominium. | String | 
+| CONDO_BA00 | A concatenation of the Borough Block and Billing lot that the condo is built on. In the case of a condo on multiple parent lots, one billing lot can represent multiple base lots.  | String | 
+| CONDO_BA01 | A concatenation of the Condo_Boro, Condo_Number and the Condo_Base_BBL fields. | String | 
+| CONDO_BA02 |  |  | 
+| CONDO_BA03 |  |  | 
 | UNIT_BORO | This is a one digit numeric field that identifies the borough in which the associated feature exists. Boro values range from one (1) to five (5) and are validated against the D_BORO domain. | String | 
 | UNIT_BLOCK | This is a 5 digit numeric field that identifies the block on which the associated feature exists. | String | 
-| UNIT_LOT | Lot is a 4 digit numberic field that identifies a unique lot within a tax block.  | String | 
+| UNIT_LOT | Lot is a 4 digit numeric field that identifies a unique lot within a tax block.  | String | 
 | UNIT_BBL | BBL is a concatenation of Borough Block Lot and is stored with every instance of those three fields.  | String | 
 | CREATED_BY | A field that can be used to identify the operator who created the feature. | String | 
 | CREATED_DA | The date the feature was created | Date | 
 | LAST_MODIF | A field that can be used to identify the operator who last modified the specific feature. | String | 
-| LAST_MOD_1 | The date the feature or any attribute value associated with it was changed. | Date | 
+| LAST_MOD00 | The date the feature or any attribute value associated with it was changed. | Date | 
 | AV_CHANGE |  | Short Integer | 
 | BW_CHANGE |  | Short Integer | 
 | EFFECTIVE_ | Effective tax year for the associated feature.  | String | 
 | UNIT_DESIG | The official unit designation for the associated feature | String | 
+| GLOBALID | | String |

--- a/Metadata/Metadata_LotFacePossessionHooks.md
+++ b/Metadata/Metadata_LotFacePossessionHooks.md
@@ -31,11 +31,12 @@ Geometry Type: SDE Feature Class<br><br>![image](https://github.com/CityOfNewYor
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
+| OBJECTID | Internal feature number. | OID | 
+| LOT_FACE_P | Indicates the type of possession hook, where 0= regular and 1= underwater. | Short Integer |
 | ROTATION | Rotation for placement of posession hooks | Double | 
 | CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
-| FID | Internal feature number. | Object ID | 
-| SHAPE | Feature geometry. | Geometry | 
-| LOT_FACE_P | Indicates the type of possession hook, where 0= regular and 1= underwater. | Short Integer | 
-| CREATED_DA | The date the record was created. | Date | 
+| CREATED_DA | The date the record was created | String | 
 | LAST_MODIF | A field that can be used to identify the operator who last modified the feature. | String | 
-| LAST_MOD_1 | The date the feature or any attribute value associated with it was changed. | Date | 
+| LAST_MOD00 | The date the feature or any attribute value associated with it was changed. | Date | 
+| GLOBALID | | String |
+| SHAPE | Feature geometry. | Geometry | 

--- a/Metadata/Metadata_MiscText.md
+++ b/Metadata/Metadata_MiscText.md
@@ -31,7 +31,8 @@ Geometry Type: SDE Feature Class<br><br>![image](https://github.com/CityOfNewYor
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| FID | Internal feature number. | Internal Feature Number | 
+| OBJECTID | Internal feature number. | OID |  
 | MISC_TEXT | The actual text entry which is placed on the map. | String | 
 | ROTATION | Rotation angle at which text is placed on the map. | Double | 
+| GLOBALID | | String |
 | SHAPE | Feature geometry. | Geometry | 

--- a/Metadata/Metadata_PossessionHooks.md
+++ b/Metadata/Metadata_PossessionHooks.md
@@ -31,11 +31,12 @@ Geometry Type: SDE Feature Class<br><br>![image](https://github.com/CityOfNewYor
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
+| OBJECTID | Internal feature number. | OID |
 | HOOK_TYPE | Short integer defining hook types | Short Integer | 
 | ROTATION | ESRI generated field denoting the display angle of the posession hook. | Double | 
 | CREATED_BY | A field that can be used to identify the operatior who created the specific feature. | String | 
-| SHAPE | Feature geometry. | Shapefile | 
-| FID | Internal feature number. | OID | 
 | CREATED_DA | The date the feature was created | Date | 
 | LAST_MODIF | A field that can be used to identify the operator who last modified the feature | String | 
-| LAST_MOD_1 | The date the feature or any attribute value associated with it was changed. | Date | 
+| LAST_MOD00 | The date the feature or any attribute value associated with it was changed. | Date | 
+| GLOBALID | | String |
+| SHAPE | Feature geometry. | Shapefile |  

--- a/Metadata/Metadata_REUCLots.md
+++ b/Metadata/Metadata_REUCLots.md
@@ -31,17 +31,18 @@ Geometry Type: SDE Table<br><br>
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| OID | Internal feature number. | Object ID | 
+| OBJECTID | Internal feature number. | Object ID | 
 | APPURTENAN | This is a one digit numeric field that identifies the borough to which the attribute is appurtenant.  Boro values range from one (1) to five (5) | String | 
-| APPURTEN_1 | Block is a five digit numeric field that identifies the block to which the attribute is appurtenant. | Long Integer | 
-| APPURTEN_2 | Lot is a four digit numberic field that identifies a unique lot within a tax block to which the attribute is appurtenant. | Short Integer | 
-| APPURTEN_3 | BBL is a cocatenation of Boro-Block-Lot and is stored with every instance of those three fields. Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing.  | String | 
+| APPURTEN00 | Block is a five digit numeric field that identifies the block to which the attribute is appurtenant. | Long Integer | 
+| APPURTEN01 | Lot is a four digit numberic field that identifies a unique lot within a tax block to which the attribute is appurtenant. | Short Integer | 
+| APPURTEN02 | BBL is a cocatenation of Boro-Block-Lot and is stored with every instance of those three fields. Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing.  | String | 
 | REUC_NUMBE |  |  | 
 | DELETED_FL |  |  | 
 | CREATED_BY | A field that can be used to identify the operator who created the specific attribute | String | 
 | CREATED_DA | The date the record was recorded. | Date | 
 | LAST_MODIF | A field that can be used to identify the operator who last modified the specific attribute | String | 
-| LAST_MOD_1 | The date the attribute was changed | Date | 
+| LAST_MOD00 | The date the attribute was changed | Date | 
 | AV_CHANGE |  |  | 
 | BW_CHANGE |  |  | 
 | EFFECTIVE_ |  |  | 
+| GLOBALID | | String |

--- a/Metadata/Metadata_SubterraneanLots.md
+++ b/Metadata/Metadata_SubterraneanLots.md
@@ -31,16 +31,17 @@ Geometry Type: SDE Table<br><br>
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| OID | Internal feature number. | OID | 
+| OBJECTID | Internal feature number. | OID | 
 | APPURTENAN | This is a one digit numeric field that identifies the borough in which the associated feature is appurtenant to.  Boro values range from one (1) to five (5)  | String | 
-| APPURTEN_1 | Block is a five digit numeric field that identifies the block on which the associated feature is appurtenant to.  | Long Integer | 
-| APPURTEN_2 | Lot is a four digit numeric field that identifies a unique lot within a tax block that the attribute is appurtenant to.  | Short Integer | 
-| APPURTEN_3 | BBL is a concatenation of Boro-Block-Lot and is stored with every instance of those three fields.  Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing, searching and the use of the files by other, as yet undetermined, applications. | String | 
+| APPURTEN00 | Block is a five digit numeric field that identifies the block on which the associated feature is appurtenant to.  | Long Integer | 
+| APPURTEN01 | Lot is a four digit numeric field that identifies a unique lot within a tax block that the attribute is appurtenant to.  | Short Integer | 
+| APPURTEN02 | BBL is a concatenation of Boro-Block-Lot and is stored with every instance of those three fields.  Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing, searching and the use of the files by other, as yet undetermined, applications. | String | 
 | SUBTERRANE | Lot is a four digit numeric field that identifies a unique lot within a tax block that the attribute is appurtenant to. Subterranean rights lot numbers must be between 8000 and 8999. | Long Integer | 
 | CREATED_BY | A field that can be used to identify the operator who created the specific attribute. | String | 
 | CREATED_DA | The date the record was created | Date | 
 | LAST_MODIF | A field that can be used to identify the operator who last modified the attribute. | String  | 
-| LAST_MOD_1 | The date the feature of any attribute value associated with it was changed.  | Date | 
+| LAST_MOD00 | The date the feature of any attribute value associated with it was changed.  | Date | 
 | AV_CHANGE |  | Short Integer | 
 | BW_CHANGE |  | Short Integer | 
 | EFFECTIVE_ |  | String | 
+| GLOBALID | | String |

--- a/Metadata/Metadata_TaxBlockPolygon.md
+++ b/Metadata/Metadata_TaxBlockPolygon.md
@@ -31,17 +31,18 @@ Geometry Type: SDE Feature Class<br><br>![image](https://github.com/CityOfNewYor
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| FID | Internal feature number. | OID | 
-| BORO | This is a one digit numeric filed that identifies the borough in which the associated feature exists. Boro values range from one (1) to five (5) and are validated against the D_BORO domain. | String | 
-| BLOCK | Block is a five digit numeric field that identifies the blokc on which the asociated feature exists.  | Long Integer | 
-| CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
-| EOP_OVERLA | Based on the block configuration and the priorities of the conversion rules, this tax block could not fit within the NYCMap polygon that defines the edge of pavement. | Short Integer | 
+| OBJECTID | Internal feature number. | OID | 
+| BORO | This is a one digit numeric field that identifies the borough in which the associated feature exists. Boro values range from one (1) to five (5) and are validated against the D_BORO domain. | String | 
+| BLOCK | Block is a five digit numeric field that identifies the block on which the associated feature exists.  | Long Integer | 
+| EOP_OVERLA | Based on the block configuration and the priorities of the conversion rules, this tax block could not fit within the NYCMap polygon that defines the edge of pavement. | Short Integer |
 | JAGGED_ST_ | Based on the block configuration and the priorities of the conversion rules, this tax block could not be aligned within the NYCMap polygon that defines the edge of pavement in such a way as to produce a straight row of tax blocks on the street. | Short Integer | 
-| SHAPE | Feature geometry. | Shape | 
+| CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
 | CREATED_DA | The date the record was created | Date | 
-| LAST_MODIF | A field that can be used to identify the operatior who last modified the specific feature | String | 
-| LAST_MOD_1 | The date the feature of any attribute value associated with it was changed | Date | 
+| MOD_BY | A field that can be used to identify the operatior who last modified the specific feature | String | 
+| MOD_DATE | The date the feature of any attribute value associated with it was changed | Date | 
 | SECTION_NU | NYC Tax Section for the specified block | Short Integer | 
 | VOLUME_NUM | Volume number of the book in which this tax lot can be found. | Short Integer | 
-| SHAPE_Area | Area of feature in internal units squared. |  | 
-| Shape_Len | This is the system derived length of the feature (where applicable) | Double | 
+| GLOBALID | | String |
+| SHAPE_AREA | Area of feature in internal units squared. |  | 
+| SHAPE_LEN | This is the system derived length of the feature (where applicable) | Double | 
+| SHAPE | Feature geometry. | Shape | 

--- a/Metadata/Metadata_TaxLotFace.md
+++ b/Metadata/Metadata_TaxLotFace.md
@@ -31,22 +31,23 @@ Geometry Type: SDE Feature Class<br><br>![image](https://github.com/CityOfNewYor
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
+| OBJECTID | Internal feature number. | Numeric | 
+| TAX_LOT_FA | This field identifies the type of each lot face line.  Lot faces are either "underwater" which as the name implies, are under water or they are "regular" meaning that they are standard lot faces existing on the land surface. | Short Integer |
 | BORO | This is a one digit numeric field that identifies the borough in which the associated feature exists.  Boro values range from one (1) to five (5) and are validated against the D_BORO domain. | String | 
 | BLOCK | Block is a five digit numeric field that identifies the block on which the associated feature exists. | Long Integer | 
-| FID | Internal feature number. | Numeric | 
 | LOT | Lot is a four digit numeric field that identifies a unique lot within a tax block.  Although DOF has a set of defined limits for different types of lots, the fact that there are exceptions to these rules makes it impossible to use a domain for validity checking of the lot numbers. | Short Integer | 
-| TAX_LOT_FA | This field identifies the type of each lot face line.  Lot faces are either "underwater" which as the name implies, are under water or they are "regular" meaning that they are standard lot faces existing on the land surface. | Short Integer | 
 | BBL | BBL is a concatenation of Boro-Block-Lot and is stored with every instance of those three fields.  Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing, searching and the use of the files by other, as yet undetermined, applications. | String | 
+| LOT_FACE_L | Length of the lot face as obtained from the original COGIS file and subsequently updated. | Double |
 | SOURCE | The Source field is populated during the conversion process and indicates where the value of "Lot_Face_Length" was obtained.  The codes used are obtained from the "D_LOT_FACE_LENGTH_SOURCE" domain | Short Integer | 
+| BLOCK_FACE | This field is obtained from the original COGIS file and identifies those lot face segments that also form part of the block face polygon. | Short Integer |
+| LOT_FACE00 | This field is set during the pre-conversion and/or the conversion process to identify lot face segments that do not conform to the required conversion rules. | Short Integer |
 | CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
+| CREATED_DA | The date the record was created | string |
+| LAST_MODIF | A field that can be used to identify the operator who last modified the specific feature. | String |
+| LAST_MOD00 | The date the feature or any attribute value associated with it was changed. | String |
 | AV_CHANGE |  |  | 
-| LOT_FACE_L | Length of the lot face as obtained from the original COGIS file and subsequently updated. | Double | 
 | BW_CHANGE |  |  | 
-| BLOCK_FACE | This field is obtained from the original COGIS file and identifies those lot face segments that also form part of the block face polygon. | Short Integer | 
-| LOT_FACE_1 | This field is set during the pre-conversion and/or the conversion process to identify lot face segments that do not conform to the required conversion rules. | Short Integer | 
-| SHAPE | Feature geometry. | Geometry | 
-| CREATED_DA | The date the record was created | string | 
-| LAST_MODIF | A field that can be used to identify the operator who last modified the specific feature. | String | 
-| LAST_MOD_1 | The date the feature or any attribute value associated with it was changed. | String | 
 | APPROX_LEN | Boolean field that indicates if the length is approximate (+/-) | Short Integer | 
-| SHAPE_Leng |  | Double | 
+| GLOBALID | | String |
+| SHAPE | Feature geometry. | Geometry |  
+| SHAPE_LEN |  | Double | 

--- a/Metadata/Metadata_TaxLotPolygon.md
+++ b/Metadata/Metadata_TaxLotPolygon.md
@@ -31,35 +31,36 @@ Geometry Type: SDE Feature Class<br><br>![image](https://github.com/CityOfNewYor
 ---------------------------------------------
 | Attribute | Description | Field Type | Sensitive Field (Y/N) | Notes| 
 |------------ | ------------- | -------- | ----------- | ----------|
-| FID | Internal feature number. | OID | 
+| OBJECTID | Internal feature number. | OID | 
 | BORO | This is a one digit numeric field that identifies the borough in which the associated feature exists.  Boro values range from one (1) to five (5) and are validated against the D_BORO domain. | Number | 
 | BLOCK | Block is a five digit numeric field that identifies the block on which the associated feature exists. | Number | 
 | LOT | Lot is a four digit numeric field that identifies a unique lot within a tax block.  Although DOF has a set of defined limits for different types of lots, the fact that there are exceptions to these rules makes it impossible to use a domain for validity checking of the lot numbers. | Number | 
 | BBL | BBL is a concatenation of Boro-Block-Lot and is stored with every instance of those three fields.  Although the BBL value can always be determined dynamically, this field is maintained in order to simplify indexing, searching and the use of the files by other, as yet undetermined, applications. | String | 
-| CONDO_FLAG | The lot defines a condominium complex | String | 
 | COMMUNITY_ |  |  | 
 | REGULAR_LO | This field is obtained from the RPAD file and identifies those lots that are rectangular. |  | 
 | NUMBER_LOT |  |  | 
+| CONDO_FLAG | The lot defines a condominium complex | String | 
 | REUC_FLAG | An REUC easement exists on part or all of this lot. | Text | 
-| LOT_NOTE |  |  | 
 | AIR_RIGHTS | An air rights easement exists on this lot. | text | 
 | SUBTERRANE | A subterranean easement exists on part or all of this lot. | String | 
 | EASEMENT_F | A land easement exists on part or all of this lot | String | 
 | SECTION_NU | NYC Tax Section for the specified lot | Number | 
 | VOLUME_NUM | Volume number of the book in which this tax lot can be found. | Number | 
 | PAGE_NUMBE | Page number on which this tax lot can be found. | Number | 
-| CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
+| LOT_NOTE |  |  | 
 | NYCMAP_BLD | This field is used to identify those lots where a building footprint associated with that lot extends beyond the lot boundary. |  | 
 | MISSING_RP | This field is used to identify physical lot polygons found in COGIS that were not matched to a record in the ORE file of RPAD. |  | 
 | CONVERSION |  |  | 
 | VALUE_REFL | This flag identifies those lots whose assessed value has been transferred to another lot. | Y/N | 
-| AV_CHANGE |  |  | 
+| CREATED_BY | A field that can be used to identify the operator who created the specific feature. | String | 
 | CREATED_DA | The date the record was created | String | 
 | LAST_MODIF | A field that can be used to identify the operator who last modified the specific feature. | String | 
-| LAST_MOD_1 | The date the feature or any attribute value associated with it was changed. | Date | 
+| LAST_MOD00 | The date the feature or any attribute value associated with it was changed. | Date | 
+| AV_CHANGE |  |  | 
 | BW_CHANGE |  |  | 
-| SHAPE | This field is used to store the geometry or shape of the features |  | 
 | EFFECTIVE_ |  |  | 
 | BILL_BBL_F | This field is used to identify the source of the Billing BBL Lot Number. | String | 
-| SHAPE_Leng | This is the system derived length of the feature (where applicable) | Number | 
-| SHAPE_Area | This is the system derived area of the feature (where applicable) | Number | 
+| GLOBALID |  | String | 
+| SHAPE | This field is used to store the geometry or shape of the features |  | 
+| SHAPE_LEN | This is the system derived length of the feature (where applicable) | Number | 
+| SHAPE_AREA | This is the system derived area of the feature (where applicable) | Number | 


### PR DESCRIPTION
Updates all taxmap* metadata to match what we get these days when downloading from open data.

Mostly this is changes to the naming convention of truncated columns.  I also reordered, added a few columns that were missing from the metadata, and did a little spell check tidying.